### PR TITLE
Fix 10

### DIFF
--- a/src/main/java/com/github/fge/filesystem/path/GenericPath.java
+++ b/src/main/java/com/github/fge/filesystem/path/GenericPath.java
@@ -129,6 +129,10 @@ public final class GenericPath
     @Override
     public Path getName(final int index)
     {
+        if (elements.root != null && elements.root.isEmpty() && elements.names.length == 0) {
+            return new GenericPath(fs, factory, PathElements.EMPTY);
+        }
+
         final String name;
 
         //noinspection ProhibitedExceptionCaught

--- a/src/main/java/com/github/fge/filesystem/path/PathElements.java
+++ b/src/main/java/com/github/fge/filesystem/path/PathElements.java
@@ -158,6 +158,33 @@ public final class PathElements
     }
 
     /**
+     * Return an array of strings starting with the root and then all of the
+     * names.
+     *
+     * @return null if there is no root and no names, otherwise as description
+     */
+    @Nonnull
+    String[] rootAndNames()
+    {
+        if (root != null && names.length == 0) {
+            return new String[] { root };
+        } else if (root == null && names.length > 0) {
+            return names;
+        } else if (root != null && names.length > 0) {
+            final String[] elements = new String[names.length + 1];
+            elements[0] = root;
+            int i = 1;
+            for (String name : names) {
+                elements[i++] = name;
+            }
+
+            return elements;
+        } else {
+            return new String[] { root == null ? "" : root };
+        }
+    }
+
+    /**
      * Returns an iterator over a set of elements of type T.
      *
      * @return an Iterator.

--- a/src/main/java/com/github/fge/filesystem/path/PathElementsFactory.java
+++ b/src/main/java/com/github/fge/filesystem/path/PathElementsFactory.java
@@ -435,7 +435,8 @@ public abstract class PathElementsFactory
     {
         final StringBuilder sb = new StringBuilder();
 
-        final boolean hasRoot = elements.root != null;
+        final String root = elements.root;
+        final boolean hasRoot = root != null;
         final String[] names = elements.names;
         final int len = names.length;
 
@@ -445,10 +446,18 @@ public abstract class PathElementsFactory
         if (len == 0)
             return sb.toString();
 
-        if (hasRoot)
+        if (hasRoot) {
             sb.append(rootSeparator);
+        }
 
-        sb.append(names[0]);
+        final String firstName = names[0];
+
+        if (hasRoot && !firstName.startsWith(separator) &&
+                       !root.endsWith(separator)) {
+            sb.append(separator);
+        }
+
+        sb.append(firstName);
 
         for (int i = 1; i < len; i++)
             sb.append(separator).append(names[i]);

--- a/src/test/java/com/github/fge/filesystem/attributes/FileAttributesFactoryTest.java
+++ b/src/test/java/com/github/fge/filesystem/attributes/FileAttributesFactoryTest.java
@@ -33,7 +33,6 @@ import java.nio.file.attribute.FileOwnerAttributeView;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Mockito.mock;
-import static org.testng.Assert.assertTrue;
 
 public final class FileAttributesFactoryTest
 {
@@ -67,7 +66,7 @@ public final class FileAttributesFactoryTest
             }
         };
 
-        assertTrue(true);
+        assertThat(true).isTrue();
     }
 
     @Test

--- a/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
+++ b/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
@@ -23,6 +23,7 @@ import com.github.fge.filesystem.provider.FileSystemFactoryProvider;
 import com.github.fge.filesystem.driver.FileSystemDriver;
 import com.github.fge.filesystem.fs.GenericFileSystem;
 import com.github.fge.filesystem.provider.FileSystemRepository;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -129,7 +130,8 @@ public final class GenericPathTest
         final PathElements elements = new PathElements("", new String[] {});
         final Path path = new GenericPath(fs, factory, elements);
 
-        path.getName(0).toString().equals("");
+        Assert.assertEquals(path.getName(0).toString(), "",
+                "First name element on empty path didn't equal an empty String");
     }
 
     /*

--- a/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
+++ b/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
@@ -120,6 +120,18 @@ public final class GenericPathTest
         assertPath(path.getFileName()).isNotNull();
     }
 
+    /* The typical behavior of a Unix path is to return a path with an
+     * empty root and no names when element 0 is requested from a path
+     * with an empty root and no names.
+     */
+    @Test
+    public void getEmptyFileNameReturnsEmptyFirstName() {
+        final PathElements elements = new PathElements("", new String[] {});
+        final Path path = new GenericPath(fs, factory, elements);
+
+        path.getName(0).toString().equals("");
+    }
+
     /*
      * This test this part of the Path's .relativize() method:
      *

--- a/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
+++ b/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
@@ -19,9 +19,9 @@
 package com.github.fge.filesystem.path;
 
 import com.github.fge.filesystem.CustomSoftAssertions;
-import com.github.fge.filesystem.provider.FileSystemFactoryProvider;
 import com.github.fge.filesystem.driver.FileSystemDriver;
 import com.github.fge.filesystem.fs.GenericFileSystem;
+import com.github.fge.filesystem.provider.FileSystemFactoryProvider;
 import com.github.fge.filesystem.provider.FileSystemRepository;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -61,26 +61,28 @@ public final class GenericPathTest
         repository = mock(FileSystemRepository.class);
         when(repository.getFactoryProvider()).thenReturn(factoryProvider);
         driver = mock(FileSystemDriver.class);
-        factory = mock(PathElementsFactory.class);
+        factory = factoryProvider.getPathElementsFactory();
         fs = new GenericFileSystem(uri, repository, driver, provider);
     }
 
     @Test
     public void isAbsoluteDelegatesToPathElementsFactory()
     {
+        final PathElementsFactory mockFactory = mock(PathElementsFactory.class);
+
         final PathElements elements1 = new PathElements("/", NO_NAMES);
         final PathElements elements2 = PathElements.EMPTY;
 
-        when(factory.isAbsolute(elements1)).thenReturn(false);
-        when(factory.isAbsolute(elements2)).thenReturn(true);
+        when(mockFactory.isAbsolute(elements1)).thenReturn(false);
+        when(mockFactory.isAbsolute(elements2)).thenReturn(true);
 
         Path path;
 
-        path = new GenericPath(fs, factory, elements1);
+        path = new GenericPath(fs, mockFactory, elements1);
 
         assertThat(path.isAbsolute()).isFalse();
 
-        path = new GenericPath(fs, factory, elements2);
+        path = new GenericPath(fs, mockFactory, elements2);
 
         assertThat(path.isAbsolute()).isTrue();
     }
@@ -132,6 +134,91 @@ public final class GenericPathTest
 
         Assert.assertEquals(path.getName(0).toString(), "",
                 "First name element on empty path didn't equal an empty String");
+    }
+
+    @Test
+    public void pathToStringWithRootDirectoryAsName() {
+        final PathElements elements
+                = new PathElements("", new String[] { "/" });
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertEquals(path.toString(), "/");
+    }
+
+    @Test
+    public void pathToStringWithRootDirectoryAndSingleName() {
+        final PathElements elements
+                = new PathElements("/", new String[] { "tmp" });
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertEquals(path.toString(), "/tmp");
+    }
+
+    @Test
+    public void pathToStringFromDirectoryRoot() {
+        final PathElements elements
+                = new PathElements("/tmp", PathElements.NO_NAMES);
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertEquals(path.toString(), "/tmp");
+    }
+
+    @Test
+    public void pathToStringFromDirectoryRootWithSubdir() {
+        final PathElements elements
+                = new PathElements("/tmp", new String[] { "foo.txt" });
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertEquals(path.toString(), "/tmp/foo.txt");
+    }
+
+    @Test
+    public void pathToStringFromDirectoryRootWithNoSubdir() {
+        final PathElements elements
+                = new PathElements("/tmp/foo.txt", PathElements.NO_NAMES);
+        FileSystemFactoryProvider provider = repository.getFactoryProvider();
+        final Path path = new GenericPath(fs, provider.getPathElementsFactory(),
+                elements);
+        Assert.assertEquals(path.toString(), "/tmp/foo.txt");
+    }
+
+    @Test
+    public void endsWithMatchesLastName() {
+        final PathElements elements
+                = new PathElements("/tmp/", new String[] { "foo.txt" });
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertTrue(path.endsWith("foo.txt"));
+        Assert.assertTrue(path.endsWith("/tmp/foo.txt"));
+    }
+
+    @Test
+    public void endsWithMatchesLastDirectoryAndName() {
+        final PathElements elements = new PathElements("/tmp",
+                new String[] { "bar", "foo.txt" });
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertTrue(path.endsWith("bar/foo.txt"));
+        Assert.assertTrue(path.endsWith("/tmp/bar/foo.txt"));
+    }
+
+    @Test
+    public void endsWithMatchesRoot() {
+        final PathElements elements
+                = new PathElements("/tmp", PathElements.NO_NAMES);
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertTrue(path.endsWith("tmp"));
+        Assert.assertTrue(path.endsWith("/tmp"));
+    }
+
+    @Test
+    public void endsWithRootDoesntMatchEmpty() {
+        final PathElements elements
+                = new PathElements("/", PathElements.NO_NAMES);
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertFalse(path.endsWith(""));
+    }
+
+    @Test
+    public void endsWithEmptyPathsMatch() {
+        final PathElements elements
+                = new PathElements("", PathElements.NO_NAMES);
+        final Path path = new GenericPath(fs, factory, elements);
+        Assert.assertTrue(path.endsWith(""));
     }
 
     /*

--- a/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
+++ b/src/test/java/com/github/fge/filesystem/path/GenericPathTest.java
@@ -23,7 +23,6 @@ import com.github.fge.filesystem.driver.FileSystemDriver;
 import com.github.fge.filesystem.fs.GenericFileSystem;
 import com.github.fge.filesystem.provider.FileSystemFactoryProvider;
 import com.github.fge.filesystem.provider.FileSystemRepository;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -132,8 +131,7 @@ public final class GenericPathTest
         final PathElements elements = new PathElements("", new String[] {});
         final Path path = new GenericPath(fs, factory, elements);
 
-        Assert.assertEquals(path.getName(0).toString(), "",
-                "First name element on empty path didn't equal an empty String");
+        assertThat(path.getName(0).toString()).isEqualTo("");
     }
 
     @Test
@@ -141,7 +139,7 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("", new String[] { "/" });
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertEquals(path.toString(), "/");
+        assertThat(path.toString()).isEqualTo("/");
     }
 
     @Test
@@ -149,7 +147,7 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("/", new String[] { "tmp" });
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertEquals(path.toString(), "/tmp");
+        assertThat(path.toString()).isEqualTo("/tmp");
     }
 
     @Test
@@ -157,7 +155,7 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("/tmp", PathElements.NO_NAMES);
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertEquals(path.toString(), "/tmp");
+        assertThat(path.toString()).isEqualTo("/tmp");
     }
 
     @Test
@@ -165,7 +163,7 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("/tmp", new String[] { "foo.txt" });
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertEquals(path.toString(), "/tmp/foo.txt");
+        assertThat(path.toString()).isEqualTo("/tmp/foo.txt");
     }
 
     @Test
@@ -175,7 +173,7 @@ public final class GenericPathTest
         FileSystemFactoryProvider provider = repository.getFactoryProvider();
         final Path path = new GenericPath(fs, provider.getPathElementsFactory(),
                 elements);
-        Assert.assertEquals(path.toString(), "/tmp/foo.txt");
+        assertThat(path.toString()).isEqualTo("/tmp/foo.txt");
     }
 
     @Test
@@ -183,8 +181,8 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("/tmp/", new String[] { "foo.txt" });
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertTrue(path.endsWith("foo.txt"));
-        Assert.assertTrue(path.endsWith("/tmp/foo.txt"));
+        assertThat(path.endsWith("foo.txt")).isTrue();
+        assertThat(path.endsWith("/tmp/foo.txt")).isTrue();
     }
 
     @Test
@@ -192,8 +190,8 @@ public final class GenericPathTest
         final PathElements elements = new PathElements("/tmp",
                 new String[] { "bar", "foo.txt" });
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertTrue(path.endsWith("bar/foo.txt"));
-        Assert.assertTrue(path.endsWith("/tmp/bar/foo.txt"));
+        assertThat(path.endsWith("bar/foo.txt")).isTrue();
+        assertThat(path.endsWith("/tmp/bar/foo.txt")).isTrue();
     }
 
     @Test
@@ -201,8 +199,8 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("/tmp", PathElements.NO_NAMES);
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertTrue(path.endsWith("tmp"));
-        Assert.assertTrue(path.endsWith("/tmp"));
+        assertThat(path.endsWith("tmp")).isTrue();
+        assertThat(path.endsWith("/tmp")).isTrue();
     }
 
     @Test
@@ -210,7 +208,7 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("/", PathElements.NO_NAMES);
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertFalse(path.endsWith(""));
+        assertThat(path.endsWith("")).isFalse();
     }
 
     @Test
@@ -218,7 +216,7 @@ public final class GenericPathTest
         final PathElements elements
                 = new PathElements("", PathElements.NO_NAMES);
         final Path path = new GenericPath(fs, factory, elements);
-        Assert.assertTrue(path.endsWith(""));
+        assertThat(path.endsWith("")).isTrue();
     }
 
     /*

--- a/src/test/java/com/github/fge/filesystem/path/PathElementsFactoryTest.java
+++ b/src/test/java/com/github/fge/filesystem/path/PathElementsFactoryTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import static org.testng.Assert.assertTrue;
 
 public final class PathElementsFactoryTest
 {
@@ -229,14 +228,14 @@ public final class PathElementsFactoryTest
             factory.relativize(elements1, elements2);
             fail("No exception thrown!");
         } catch (IllegalArgumentException ignored) {
-            assertTrue(true);
+            assertThat(true).isTrue();
         }
 
         try {
             factory.relativize(elements2, elements1);
             fail("No exception thrown!");
         } catch (IllegalArgumentException ignored) {
-            assertTrue(true);
+            assertThat(true).isTrue();
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/fge/java7-fs-base/issues/8

There was a lot more work done in this PR than I would have liked there to be. I was forced to base it off of my previous PR, so that I could act with the assumptions related to an empty path. There were a lot of assumptions that were tied to each other in how Paths were defined. I've continued to use the patterns established by the JVM's UnixPath behavior.

In this PR, I updated how toString() behaves for paths that have an empty rootSeparator (e.g. UnixPath) so that they don't output a String with an embedded "null" in them. I've also modified how endsWith() behaves so that it conforms to the expectations of UnixPath and doesn't throw an exception when trying to access an element of an array that is unavailable.

Please let me know if these PRs are welcome or if they are a nuisance. I'm actively developing an NIO plugin and I would like to get this project to a solid next release.
